### PR TITLE
:barber: After testing on Debian

### DIFF
--- a/emoji-commit.gemspec
+++ b/emoji-commit.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'thor'
-  spec.add_dependency 'json', '~> 1.8.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/file-tasks.rb
+++ b/lib/file-tasks.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require 'fileutils'
-require 'Thor'
+require 'thor'
 
 module EmojiCommit
   class Cli < Thor


### PR DESCRIPTION
After waiting hours for Debian to d/l :zzz: using a vanilla build of Debian there were a couple of errors.

1) The JSON gem building its native extensions was :hankey: So removed the dependency from the gemspec again - this could be fixed by working through the issues (I would expect most Debian users should be fine, however 1.8.1 is installed by default so it's all good.)

2) ```require 'Thor' ``` didn't work and should be ```require 'thor'```

Neither change breaks the gem on Mac OS X with RVM & MRI 2.2.3.

Now also works on Debian with MRI 2.1.5.

The previous JSON v1.8.3 issue should be fixed on Debian. I'll get Debian to install 1.8.3 and try it though.

You can try to make it work on Windows :grimacing: 